### PR TITLE
autodetect: assume running self managed cluster if cannot detect type

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -18,9 +18,6 @@ autoDetectEnvironment(){
 		PLATFORM="kind"
 	elif [[ $CURRENT_CONTEXT_NAME =~ ^k3d-.* ]]; then
 		PLATFORM="k3d"
-	else
-		echo "No k8s cluster configured or unknown env!"
-		exit 2
 	fi
 }
 

--- a/common.sh
+++ b/common.sh
@@ -18,7 +18,13 @@ autoDetectEnvironment(){
 		PLATFORM="kind"
 	elif [[ $CURRENT_CONTEXT_NAME =~ ^k3d-.* ]]; then
 		PLATFORM="k3d"
-	fi
+        elif [[ $CURRENT_CONTEXT_NAME =~ ^kubernetes-.* ]]; then
+                PLATFORM="self-managed"
+        else
+                echo "No k8s cluster configured or unknown env!"
+                exit 2
+        fi
+   fi
 }
 
 handleKubearmor(){


### PR DESCRIPTION
If we already have `CURRENT_CONTEXT_NAME` then it is safe to assume we're running a cluster.
This PR allows the script to be run on self managed clusters